### PR TITLE
uncommented attribution

### DIFF
--- a/scripts/stackoverflow/inject.js
+++ b/scripts/stackoverflow/inject.js
@@ -1,20 +1,36 @@
 'use strict';
 
+
 Array.from(document.getElementsByTagName('pre')) // get all code snippets
 .forEach(function (block) {
 	
 	block.addEventListener('dblclick', function (event) {
 		// Reference: http://stackoverflow.com/a/6462980/3485241
 		
+		//gets the address of the current page
+		var codeAttribution = '<br/><br/> source: ' + window.location.toString(),
+		copyText = block.innerHTML;
+		
+		copyText = copyText + codeAttribution;
+		//copy old HTML
+		var oldHTML = block.innerHTML;
+		
+		//replace with new HTML
+		block.innerHTML = copyText;
+		
 		// Add snippet to range
 		var range = document.createRange();
 		range.selectNode(block);
-
+		
+		
 		// Copy snippet to clipboard
 		try {
 			window.getSelection().addRange(range);
 			document.execCommand('copy');
 			window.getSelection().removeAllRanges();
+			
+			//replace new with old HTML
+			block.innerHTML = oldHTML;
 			block.style.border = '2px solid #0D0';
 			setTimeout(function () {
 			  return block.style.border = 'none';


### PR DESCRIPTION
Due to the fact that code could be coming from any language, without major work we couldn't safely assume the commenting syntax. Because of this, I figured it would be best to leave it up to the person doing to copying (the programmer, in all likelihood) to comment out the source.

in a future update we could have this as a setting that is off by default.