### PR TITLE
Dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Chrome and Firefox extension to copy code snippet from Stack Overflow by double 
 We :heart: contributions. Feel free to send us a PR.
 
 1. [Create an issue](https://github.com/studenton/cutcode/issues/new) if there is one.
-2. [Fork the repo] (https://github.com/studenton/cutcode/fork).
+2. [Fork the repo](https://github.com/studenton/cutcode/fork).
 3. Create your feature branch (`git checkout -b your-feature`).
 4. Add and commit your changes (`git commit -am 'message'`).
 5. Push the branch (`git push origin your-feature`).

--- a/Settings/UserSettings.html
+++ b/Settings/UserSettings.html
@@ -1,0 +1,27 @@
+<!Doctype html>
+<html>
+  <head>
+    <link rel="stylesheet" type="text/css" href="settings.css">
+    <title>Cutcode Options</title>
+  </head>
+
+  <body>
+    <h1> Cutcode Options </h1>
+    <div id="status"></div>
+    <form class="options">
+      <h3>Select the  maximum number of code snippets to be saved (max 12)</h3>
+      <input type="number" id="snippets" min="0" max="12">
+
+      <h3>Select how many characters of each code snippet should be displayed (max 500)</h3>
+      <input type="number" id="chars" min="1" max="500">
+      <br/>
+      <br/>
+
+      <button id="save"> Save Options </button>
+      <a href="#" target="_blank" id="options_link">View recent code snippets in a separate page</a>
+    </form>
+
+
+    <script src="settings.js"></script>
+  </body>
+</html>

--- a/Settings/settings.css
+++ b/Settings/settings.css
@@ -1,0 +1,20 @@
+table{
+  margin: 0 auto;
+}
+
+th{
+  border: 1px solid black;
+}
+
+td{
+  border: 1px solid black;
+}
+
+#status{
+  color:blue;
+  float:right;
+  position:relative;
+  height: 1.2rem;
+  width: 5%;
+  bottom:2rem;
+}

--- a/Settings/settings.js
+++ b/Settings/settings.js
@@ -1,0 +1,99 @@
+//writes options selected by user to the Chrome remote (sync) Storage API
+function save_options(){
+  var snippets = document.getElementById('snippets').value;
+  var chars = document.getElementById('chars').value;
+
+  if(snippets === ""){
+    snippets = 5;
+  }
+  if(chars ===""){
+    chars = 500;
+  }
+  chrome.storage.sync.set({
+    numSnippets: snippets,
+    numChars: chars
+  }, function(){
+    document.getElementById("status").innerText = "Saved";
+    setTimeout(function(){
+      document.getElementById("status").innerText = "";
+    }, 750);
+  });
+}
+
+//updates DOM with user Selected options. This function is called whenever the
+//remote storage is updated
+function updateOptionsValues(numSnippets=5, numChars=500){
+
+  document.getElementById('snippets').value = numSnippets;
+  document.getElementById('chars').value = numChars;
+}
+
+//helper function to update the DOM with our history of snippets whenever
+//the Options modal/tab is opened
+function updateSnippetHistory(snippetObject){
+  entry = document.createElement("tr");
+  entry.innerHTML = "<td>"+"</td>"
+                     +"<td>" +snippetObject.URI + "</td>"
+                     +"<td>" + snippetObject.date + "</td>";
+  entry.firstChild.innerText = snippetObject.snippet;
+  document.querySelector(".snippet-history").appendChild(entry);
+}
+
+//when the remote storage object is updated, this function is fired
+//it will then call updateOptionsValues in order to update the DOM
+chrome.storage.onChanged.addListener(function(changes, namespace){
+  var newSnippetsNumber;
+  var newCharsNumber;
+
+  if(changes.numSnippets){
+    newSnippetsNumber = changes.numSnippets.newValue;
+  }
+  if(changes.numChars){
+    newCharsNumber = changes.numChars.newValue;
+  }
+  updateOptionsValues(newSnippetsNumber, newCharsNumber);
+
+});
+
+
+//saves options when the form is submitted
+document.querySelector('form').addEventListener('submit', function(event){
+  event.preventDefault();
+  save_options();
+});
+
+//open options in a separate page when the link is clicked
+document.getElementById('options_link').addEventListener('click', function(){
+    window.close();
+    chrome.runtime.openOptionsPage();
+    });
+
+//this function is called to set up the default options when options is opened. On the very first pass,
+//all three options will be null, so they are set here. The DOM will be updated
+//by updateOptionsValues
+chrome.storage.sync.get(null, function(result){
+  updateOptionsValues(result.numSnippets, result.numChars);
+  if(!result.snippetHistory){
+    chrome.storage.sync.set({snippetHistory: []});
+  }
+});
+
+//draws the table with live Snippet History info whenever the options
+//modal or page is opened
+window.onload = function(){
+  table = document.createElement("table")
+  table.className = "snippet-history"
+  table.innerHTML = `<tr>
+                      <th>Code Snippet</th>
+                      <th>URL</th>
+                      <th>Date</th>
+                    </tr>`;
+  document.querySelector("body").appendChild(table);
+  chrome.storage.sync.get("snippetHistory", function(result){
+    snipArray = result.snippetHistory;
+    console.log(snipArray);
+    for(var i=0; i<snipArray.length; i++){
+      updateSnippetHistory(snipArray[i]);
+    }
+  })
+}

--- a/Settings/settings.js
+++ b/Settings/settings.js
@@ -1,4 +1,4 @@
-//writes options selected by user to the Chrome remote (sync) Storage API
+//writes options selected by user to the Chrome remote (local) Storage API
 function save_options(){
   var snippets = document.getElementById('snippets').value;
   var chars = document.getElementById('chars').value;
@@ -9,7 +9,7 @@ function save_options(){
   if(chars ===""){
     chars = 500;
   }
-  chrome.storage.sync.set({
+  chrome.storage.local.set({
     numSnippets: snippets,
     numChars: chars
   }, function(){
@@ -71,10 +71,10 @@ document.getElementById('options_link').addEventListener('click', function(){
 //this function is called to set up the default options when options is opened. On the very first pass,
 //all three options will be null, so they are set here. The DOM will be updated
 //by updateOptionsValues
-chrome.storage.sync.get(null, function(result){
+chrome.storage.local.get(null, function(result){
   updateOptionsValues(result.numSnippets, result.numChars);
   if(!result.snippetHistory){
-    chrome.storage.sync.set({snippetHistory: []});
+    chrome.storage.local.set({snippetHistory: []});
   }
 });
 
@@ -89,7 +89,7 @@ window.onload = function(){
                       <th>Date</th>
                     </tr>`;
   document.querySelector("body").appendChild(table);
-  chrome.storage.sync.get("snippetHistory", function(result){
+  chrome.storage.local.get("snippetHistory", function(result){
     snipArray = result.snippetHistory;
     console.log(snipArray);
     for(var i=0; i<snipArray.length; i++){

--- a/manifest.json
+++ b/manifest.json
@@ -4,9 +4,14 @@
 	"description": "Double click to copy code from Stack Overflow.",
 	"author": "Amit Chaudhary <studenton.com@gmail.com>",
 	"homepage_url": "https://github.com/studenton/cutcode",
+	"options_ui": {
+		"page": "Settings/UserSettings.html",
+		"chrome_style": true
+	},
 	"manifest_version": 2,
 	"permissions": [
-		"clipboardWrite"
+		"clipboardWrite",
+		"storage"
 	],
 	"content_scripts": [{
 		"matches": ["*://*.stackoverflow.com/*", "*://*.stackexchange.com/*", "*://github.com/*"],

--- a/scripts/stackoverflow/inject.js
+++ b/scripts/stackoverflow/inject.js
@@ -9,12 +9,22 @@ Array.from(document.getElementsByTagName('pre')) // get all code snippets
 		// Add snippet to range
 		var range = document.createRange();
 		range.selectNode(block);
-		console.log(range.extractContents());
+		
 
 		// Copy snippet to clipboard
 		try {
 			window.getSelection().addRange(range);
 			document.execCommand('copy');
+			chrome.storage.sync.get("snippetHistory", function(result){
+				console.log(result.snippetHistory);
+				result.snippetHistory.unshift({
+					snippet: range.toString(),
+				  URI: range.commonAncestorContainer.baseURI,
+					date: Date.now()
+				});
+				chrome.storage.sync.set({snippetHistory: result.snippetHistory});
+			});
+
 			window.getSelection().removeAllRanges();
 			block.style.outline = '2px solid #0D0';
 			setTimeout(function () {

--- a/scripts/stackoverflow/inject.js
+++ b/scripts/stackoverflow/inject.js
@@ -4,15 +4,15 @@
 //the first time the extension is loaded up. It sets up
 //default values for our options and initializes snippetHistory
 //to an empty array
-chrome.storage.sync.get(null, function(result){
+chrome.storage.local.get(null, function(result){
   if(!result.snippetHistory){
-    chrome.storage.sync.set({snippetHistory: []});
+    chrome.storage.local.set({snippetHistory: []});
   }
 	if(!result.numSnippets){
-    chrome.storage.sync.set({numSnippets: 5});
+    chrome.storage.local.set({numSnippets: 5});
   }
 	if(!result.numChars){
-    chrome.storage.sync.set({numChars: 500});
+    chrome.storage.local.set({numChars: 500});
   }
 });
 
@@ -31,7 +31,7 @@ Array.from(document.getElementsByTagName('pre')) // get all code snippets
 		try {
 			window.getSelection().addRange(range);
 			document.execCommand('copy');
-			chrome.storage.sync.get(null, function(result){
+			chrome.storage.local.get(null, function(result){
 				console.log(result);
 				//if grabbing this snippet results in exceeding the
 				//specified number, pop off the oldes one
@@ -46,7 +46,7 @@ Array.from(document.getElementsByTagName('pre')) // get all code snippets
 				  URI: range.commonAncestorContainer.baseURI,
 					date: new Date().toString()
 				});
-				chrome.storage.sync.set({snippetHistory: result.snippetHistory});
+				chrome.storage.local.set({snippetHistory: result.snippetHistory});
 			});
 
 			window.getSelection().removeAllRanges();

--- a/scripts/stackoverflow/inject.js
+++ b/scripts/stackoverflow/inject.js
@@ -15,9 +15,9 @@ Array.from(document.getElementsByTagName('pre')) // get all code snippets
 			window.getSelection().addRange(range);
 			document.execCommand('copy');
 			window.getSelection().removeAllRanges();
-			block.style.border = '2px solid #0D0';
+			block.style.outline = '2px solid #0D0';
 			setTimeout(function () {
-			  return block.style.border = 'none';
+			  return block.style.outline = 'none';
 			}, 500);
 		} catch (err) {
 			console.log('Failed to copy', err);

--- a/scripts/stackoverflow/inject.js
+++ b/scripts/stackoverflow/inject.js
@@ -2,13 +2,14 @@
 
 Array.from(document.getElementsByTagName('pre')) // get all code snippets
 .forEach(function (block) {
-	
+
 	block.addEventListener('dblclick', function (event) {
 		// Reference: http://stackoverflow.com/a/6462980/3485241
-		
+
 		// Add snippet to range
 		var range = document.createRange();
 		range.selectNode(block);
+		console.log(range.extractContents());
 
 		// Copy snippet to clipboard
 		try {


### PR DESCRIPTION
Fixes #23 

Using `chrome.storage.local` API, the extension can now save up to 5 snippets in history. Accessible through the extension's settings page.