### PR TITLE
Added setting to choose in which websites the extension works

### DIFF
--- a/Settings/UserSettings.html
+++ b/Settings/UserSettings.html
@@ -17,10 +17,20 @@
       <br/>
       <br/>
 
+      <h3>Select what websites you want the extension to work on, separated by commas</h3>
+      <p>Just addresses including a dot are considered. <strong>A single dot stands for any page</strong>.</p>
+      <p><strong>Example: </strong>stackoverflow.com, askubuntu.com, http://stackexchange.com</p>
+      <textarea id="allowed-sites" rows="5" cols="55"></textarea>
+      <br/>
+      <br/>
+
       <button id="save"> Save Options </button>
       <a href="#" target="_blank" id="options_link">View recent code snippets in a separate page</a>
     </form>
 
+    <br/>
+    <hr/>
+    <br/>
 
     <script src="settings.js"></script>
   </body>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "Cutcode",
 	"version": "0.1.0",
-	"description": "Double click to copy code from Stack Overflow.",
+	"description": "Double click to copy code from Stack Overflow or other custom sites",
 	"author": "Amit Chaudhary <studenton.com@gmail.com>",
 	"homepage_url": "https://github.com/studenton/cutcode",
 	"options_ui": {
@@ -14,7 +14,7 @@
 		"storage"
 	],
 	"content_scripts": [{
-		"matches": ["*://*.stackoverflow.com/*", "*://*.stackexchange.com/*", "*://github.com/*"],
+		"matches": ["https://*/*", "http://*/*"],
 		"js": ["scripts/stackoverflow/inject.js"],
 		"run_at": "document_end"
 	}],

--- a/scripts/stackoverflow/inject.js
+++ b/scripts/stackoverflow/inject.js
@@ -1,62 +1,78 @@
 'use strict';
 
-//Executed when the extension is invoked. This will only do things
-//the first time the extension is loaded up. It sets up
-//default values for our options and initializes snippetHistory
-//to an empty array
-chrome.storage.local.get(null, function(result){
-  if(!result.snippetHistory){
-    chrome.storage.local.set({snippetHistory: []});
-  }
-	if(!result.numSnippets){
-    chrome.storage.local.set({numSnippets: 5});
-  }
-	if(!result.numChars){
-    chrome.storage.local.set({numChars: 500});
-  }
-});
+//Checking first if we're in one of the websites the user selected
+chrome.storage.local.get(null, function (result) {
+	var allowedSites = result.allowedSites;
+	if(!result.allowedSites) {
+		allowedSites = ["stackoverflow.com"];
+		chrome.storage.local.set({allowedSites: allowedSites});
+	}
+	for (let i = 0; i < allowedSites.length; i++) {
+		//If the website is indeed one of the allowed
+		if (window.location.href.indexOf(allowedSites[i]) > -1) {
 
-Array.from(document.getElementsByTagName('pre')) // get all code snippets
-.forEach(function (block) {
-
-	block.addEventListener('dblclick', function (event) {
-		// Reference: http://stackoverflow.com/a/6462980/3485241
-
-		// Add snippet to range
-		var range = document.createRange();
-		range.selectNode(block);
-
-
-		// Copy snippet to clipboard
-		try {
-			window.getSelection().removeAllRanges();
-			window.getSelection().addRange(range);
-			document.execCommand('copy');
-			chrome.storage.local.get(null, function(result){
-				console.log(result);
-				//if grabbing this snippet results in exceeding the
-				//specified number, pop off the oldes one
-				if(result.snippetHistory.length >= result.numSnippets){
-					result.snippetHistory.pop();
+			//Executed when the extension is invoked. This will only do things
+			//the first time the extension is loaded up. It sets up
+			//default values for our options and initializes snippetHistory
+			//to an empty array
+			chrome.storage.local.get(null, function (result) {
+				if (!result.snippetHistory) {
+					chrome.storage.local.set({ snippetHistory: [] });
 				}
-
-				//add this snippet as the most recent. Entry is controlled
-				//by user options
-				result.snippetHistory.unshift({
-					snippet: range.toString().substring(0, Number(result.numChars)),
-				  URI: range.commonAncestorContainer.baseURI,
-					date: new Date().toString()
-				});
-				chrome.storage.local.set({snippetHistory: result.snippetHistory});
+				if (!result.numSnippets) {
+					chrome.storage.local.set({ numSnippets: 5 });
+				}
+				if (!result.numChars) {
+					chrome.storage.local.set({ numChars: 500 });
+				}
 			});
 
-			window.getSelection().removeAllRanges();
-			block.style.outline = '2px solid #0D0';
-			setTimeout(function () {
-			  return block.style.outline = 'none';
-			}, 500);
-		} catch (err) {
-			console.log('Failed to copy', err);
+			Array.from(document.getElementsByTagName('pre')) // get all code snippets
+				.forEach(function (block) {
+
+					block.addEventListener('dblclick', function (event) {
+						// Reference: http://stackoverflow.com/a/6462980/3485241
+
+						// Add snippet to range
+						var range = document.createRange();
+						range.selectNode(block);
+
+
+						// Copy snippet to clipboard
+						try {
+							window.getSelection().removeAllRanges();
+							window.getSelection().addRange(range);
+							document.execCommand('copy');
+							chrome.storage.local.get(null, function (result) {
+								console.log(result);
+								//if grabbing this snippet results in exceeding the
+								//specified number, pop off the oldes one
+								if (result.snippetHistory.length >= result.numSnippets) {
+									result.snippetHistory.pop();
+								}
+
+								//add this snippet as the most recent. Entry is controlled
+								//by user options
+								result.snippetHistory.unshift({
+									snippet: range.toString().substring(0, Number(result.numChars)),
+									URI: range.commonAncestorContainer.baseURI,
+									date: new Date().toString()
+								});
+								chrome.storage.local.set({ snippetHistory: result.snippetHistory });
+							});
+
+							window.getSelection().removeAllRanges();
+							block.style.outline = '2px solid #0D0';
+							setTimeout(function () {
+								return block.style.outline = 'none';
+							}, 500);
+						} catch (err) {
+							console.log('Failed to copy', err);
+						}
+					});
+				});
+
+			break;
 		}
-	});
+	}
 });


### PR DESCRIPTION
Referencing #32, I added a new textarea in the configuration where you can enter the websites in which you want the extension to work, separated by commas. By default, just StackOverflow is enabled.

Note that I had to change the manifest in order for the extension to have access to all the websites visited by the user instead of just a few ones:
`"matches": ["https://*/*", "http://*/*"]`

Let me know what you think, as this is my first PR.